### PR TITLE
Support the new Mapbox Standard Style

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ const map = new mapboxgl.Map({
     zoom: 9
 });
 map.on('load', () => {
+    map.current.addLayer({
+        id: "traffic-root",
+        type: "slot",
+    })
     map.addControl(new MapboxTraffic());
 });
 ```

--- a/mapbox-gl-traffic.js
+++ b/mapbox-gl-traffic.js
@@ -954,12 +954,8 @@ MapboxTraffic.prototype.render = function () {
       url: 'mapbox://mapbox.mapbox-traffic-v1'
     });
 
-    var roadLayers = this._map.getStyle().layers.filter(function (layer) {
-      return layer['source-layer'] === 'road';
-    });
-    var topRoadLayer = roadLayers[roadLayers.length - 1].id;
     var style = this._map.getStyle();
-    var trafficStyle = addLayers(style, trafficLayers, topRoadLayer);
+    var trafficStyle = addLayers(style, trafficLayers, 'traffic-root');
     this._map.setStyle(trafficStyle);
   }
 

--- a/mapbox-gl-traffic.js
+++ b/mapbox-gl-traffic.js
@@ -50,6 +50,7 @@ var trafficLayers = [
           ]
         ]
       },
+      'line-emissive-strength': 0.8,
       'line-color': {
         'base': 1,
         'type': 'categorical',
@@ -154,6 +155,7 @@ var trafficLayers = [
           ]
         ]
       },
+      'line-emissive-strength': 0.8,
       'line-color': {
         'base': 1,
         'type': 'categorical',
@@ -265,6 +267,7 @@ var trafficLayers = [
           ]
         ]
       },
+      'line-emissive-strength': 0.8,
       'line-color': {
         'base': 1,
         'type': 'categorical',
@@ -380,6 +383,7 @@ var trafficLayers = [
           ]
         ]
       },
+      'line-emissive-strength': 0.8,
       'line-color': {
         'base': 1,
         'type': 'categorical',
@@ -483,6 +487,7 @@ var trafficLayers = [
           ]
         ]
       },
+      'line-emissive-strength': 0.8,
       'line-color': {
         'base': 1,
         'type': 'categorical',
@@ -558,6 +563,7 @@ var trafficLayers = [
           ]
         ]
       },
+      'line-emissive-strength': 0.8,
       'line-color': {
         'base': 1,
         'type': 'categorical',
@@ -629,6 +635,7 @@ var trafficLayers = [
           ]
         ]
       },
+      'line-emissive-strength': 0.8,
       'line-color': {
         'base': 1,
         'type': 'categorical',
@@ -696,6 +703,7 @@ var trafficLayers = [
           ]
         ]
       },
+      'line-emissive-strength': 0.8,
       'line-color': {
         'base': 1,
         'type': 'categorical',
@@ -759,6 +767,7 @@ var trafficLayers = [
           ]
         ]
       },
+      'line-emissive-strength': 0.8,
       'line-color': {
         'base': 1,
         'type': 'categorical',
@@ -834,6 +843,7 @@ var trafficLayers = [
           ]
         ]
       },
+      'line-emissive-strength': 0.8,
       'line-color': {
         'base': 1,
         'type': 'categorical',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/mapbox-gl-traffic",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "description": "Mapbox GL JS plugin for enabling/disabling traffic",
   "main": "mapbox-gl-traffic.js",
   "scripts": {


### PR DESCRIPTION
With the update to Mapbox GL JS 3 and the introduction of the new Mapbox Standard Style, the layers with `source-layer: 'road'` seem to have disappeared. The workaround I've found is to add a custom layer with an ID of `traffic-root` just before initializing the Mapbox Traffic Layer. This change directly looks for that new layer.

Another new thing in the Mapbox Standard Style are the new light presets: "dawn", "day", "dusk", and "night". However, in the darker presets, the traffic lines dim substantially - it's very hard to tell the 'low' green from the 'severe' red!

By adding the [new `line-emissive-strength' property](https://docs.mapbox.com/mapbox-gl-js/example/set-config-property/) to each layer, they are significantly more visible in all four light presets.

